### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![](https://api.travis-ci.org/heroku/ranch_proxy_protocol.svg?branch=master)
 
 This module wraps the `ranch_tcp` module to parse the
-[proxy protocol](http://haproxy.1wt.eu/download/1.5/doc/proxy-protocol.txt)
+[proxy protocol](https://www.haproxy.org/download/1.5/doc/proxy-protocol.txt)
 (version 1) before handing the socket on to the `ranch` handler.
 
 It has the same API as the `ranch_tcp` module but with two new

--- a/src/ranch_proxy_protocol.erl
+++ b/src/ranch_proxy_protocol.erl
@@ -1,5 +1,5 @@
 %%% @copyright (C) 2015, Heroku
-%%% @doc Ranch protocol handling for the HA Proxy PROXY protocol [http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt]
+%%% @doc Ranch protocol handling for the HA Proxy PROXY protocol [https://www.haproxy.org/download/1.5/doc/proxy-protocol.txt]
 %%% @end
 -module(ranch_proxy_protocol).
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://haproxy.1wt.eu/download/1.5/doc/proxy-protocol.txt (301) with 1 occurrences migrated to:  
  https://www.haproxy.org/download/1.5/doc/proxy-protocol.txt ([https](https://haproxy.1wt.eu/download/1.5/doc/proxy-protocol.txt) result 301).
* http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt with 1 occurrences migrated to:  
  https://www.haproxy.org/download/1.5/doc/proxy-protocol.txt ([https](https://www.haproxy.org/download/1.5/doc/proxy-protocol.txt) result 301).